### PR TITLE
Removed unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "url": "https://github.com/boraseoksoon/programming-language-detector/issues"
   },
   "homepage": "https://github.com/boraseoksoon/programming-language-detector#readme",
-  "dependencies": {
-    "child_process": "^1.0.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "jest": "^26.4.2",
     "shadow-cljs": "^2.11.4"


### PR DESCRIPTION
Built-in libraries don't need to be listed as a dependency in package.json, and packages like `child_process` (on the NPM registry, not the built-in ones) are often used to spread malware; see https://github.com/npm/security-holder